### PR TITLE
Remove macos 10.14 job from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,14 +25,6 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: macos1014_cpython
-          image_name: macos-10.14
-          python_versions: ['3.6', '3.7', '3.8', '3.9']
-          test_suites:
-              all: venv/bin/pytest -n 2 -vvs
-
-    - template: etc/ci/azure-posix.yml
-      parameters:
           job_name: macos1015_cpython
           image_name: macos-10.15
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']


### PR DESCRIPTION
I've removed the macos 10.14 job from azure-piplines.yml as it is no longer available on Azure Piplines.