### PR TITLE
Do not use Python 3.6 on Windows 2022 jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,16 +33,16 @@ jobs:
 
     - template: etc/ci/azure-win.yml
       parameters:
-          job_name: win2022_cpython
-          image_name: windows-2022
+          job_name: win2019_cpython
+          image_name: windows-2019
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs
 
     - template: etc/ci/azure-win.yml
       parameters:
-          job_name: win2019_cpython
-          image_name: windows-2019
-          python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
+          job_name: win2022_cpython
+          image_name: windows-2022
+          python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs


### PR DESCRIPTION
    * Python 3.6 is not available on Windows 2022 images

Signed-off-by: Jono Yang <jyang@nexb.com>