### PR TITLE
Add docs option in configure

### DIFF
--- a/configure
+++ b/configure
@@ -30,6 +30,7 @@ CLI_ARGS=$1
 # Requirement arguments passed to pip and used by default or with --dev.
 REQUIREMENTS="--editable . --constraint requirements.txt"
 DEV_REQUIREMENTS="--editable .[testing] --constraint requirements.txt --constraint requirements-dev.txt"
+DOCS_REQUIREMENTS="--editable .[docs] --constraint requirements.txt"
 
 # where we create a virtualenv
 VIRTUALENV_DIR=venv
@@ -177,6 +178,7 @@ while getopts :-: optchar; do
                 help  ) cli_help;;
                 clean ) find_python && clean;;
                 dev   ) CFG_REQUIREMENTS="$DEV_REQUIREMENTS";;
+                docs   ) CFG_REQUIREMENTS="$DOCS_REQUIREMENTS";;
             esac;;
     esac
 done

--- a/configure.bat
+++ b/configure.bat
@@ -28,6 +28,7 @@
 @rem # Requirement arguments passed to pip and used by default or with --dev.
 set "REQUIREMENTS=--editable . --constraint requirements.txt"
 set "DEV_REQUIREMENTS=--editable .[testing] --constraint requirements.txt --constraint requirements-dev.txt"
+set "DOCS_REQUIREMENTS=--editable .[docs] --constraint requirements.txt"
 
 @rem # where we create a virtualenv
 set "VIRTUALENV_DIR=venv"
@@ -76,6 +77,9 @@ if not "%1" == "" (
     if "%1" EQU "--clean"  (goto clean)
     if "%1" EQU "--dev"    (
         set "CFG_REQUIREMENTS=%DEV_REQUIREMENTS%"
+    )
+    if "%1" EQU "--docs"    (
+        set "CFG_REQUIREMENTS=%DOCS_REQUIREMENTS%"
     )
     shift
     goto again


### PR DESCRIPTION
Adds a --docs option to the configure script to also install requirements
for the documentation builds.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>