### PR TITLE
Remove thirdparty and update ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu18_cpython
-          image_name: ubuntu-18.04
+          job_name: ubuntu22_cpython
+          image_name: ubuntu-22.04
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
@@ -25,8 +25,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: macos1015_cpython
-          image_name: macos-10.15
+          job_name: macos12_cpython
+          image_name: macos-12
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,9 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu22_cpython
-          image_name: ubuntu-22.04
-          python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
+          job_name: ubuntu18_cpython
+          image_name: ubuntu-18.04
+          python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -19,7 +19,15 @@ jobs:
       parameters:
           job_name: ubuntu20_cpython
           image_name: ubuntu-20.04
-          python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
+          test_suites:
+              all: venv/bin/pytest -n 2 -vvs
+
+    - template: etc/ci/azure-posix.yml
+      parameters:
+          job_name: ubuntu22_cpython
+          image_name: ubuntu-22.04
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -27,7 +35,7 @@ jobs:
       parameters:
           job_name: macos12_cpython
           image_name: macos-12
-          python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -35,7 +43,7 @@ jobs:
       parameters:
           job_name: macos11_cpython
           image_name: macos-11
-          python_versions: ['3.7', '3.8', '3.9', '3.10']
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -43,7 +51,7 @@ jobs:
       parameters:
           job_name: win2019_cpython
           image_name: windows-2019
-          python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs
 
@@ -51,6 +59,6 @@ jobs:
       parameters:
           job_name: win2022_cpython
           image_name: windows-2022
-          python_versions: ['3.7', '3.8', '3.9', '3.10']
+          python_versions: ['3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs

--- a/thirdparty/README.rst
+++ b/thirdparty/README.rst
@@ -1,2 +1,0 @@
-Put your Python dependency wheels to be vendored in this directory.
-


### PR DESCRIPTION
This commit is to remove the thirdparty/ and fix the deprecated image from Azure.

The following images are deprecated in GitHub actions and Azure DevOps:

* `ubuntu-18.04` : https://github.com/actions/runner-images/issues/6002
* `macos-10.15` : https://github.com/actions/runner-images/issues/5583

Due to this there was failing tests due to planned brownouts