### PR TITLE
Remove deprecated github-actions/azure images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,14 +9,6 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu18_cpython
-          image_name: ubuntu-18.04
-          python_versions: ['3.7', '3.8', '3.9', '3.10', '3.11']
-          test_suites:
-              all: venv/bin/pytest -n 2 -vvs
-
-    - template: etc/ci/azure-posix.yml
-      parameters:
           job_name: ubuntu20_cpython
           image_name: ubuntu-20.04
           python_versions: ['3.7', '3.8', '3.9', '3.10', '3.11']
@@ -27,14 +19,6 @@ jobs:
       parameters:
           job_name: ubuntu22_cpython
           image_name: ubuntu-22.04
-          python_versions: ['3.7', '3.8', '3.9', '3.10', '3.11']
-          test_suites:
-              all: venv/bin/pytest -n 2 -vvs
-
-    - template: etc/ci/azure-posix.yml
-      parameters:
-          job_name: macos1015_cpython
-          image_name: macos-10.15
           python_versions: ['3.7', '3.8', '3.9', '3.10', '3.11']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs


### PR DESCRIPTION
- remove deprecated `ubuntu-18.04` image See https://github.com/actions/runner-images/issues/6002 (Will be deprecated in 3 days, failing already)
- remove deprecated `macos-10.15` image See https://github.com/actions/runner-images/issues/5583 (Deprecated some months back)

