### PR TITLE
Pin Sphinx version to 6.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,6 @@ testing =
     isort
 
 docs =
-    Sphinx >= 3.3.1
+    Sphinx == 6.2.1
     sphinx-rtd-theme >= 0.5.0
     doc8 >= 0.8.1


### PR DESCRIPTION
We are pinning Sphinx to 6.2.1 to avoid the test failures we get when running Sphinx 7.0.0