### PR TITLE
Added PDF and ePub download option for RTD documentation as requested in https://github.com/nexB/aboutcode/pull/127

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+# Build PDF & ePub
+formats:
+  - epub
+  - pdf
+
 # Where the Sphinx conf.py file is located
 sphinx:
    configuration: docs/source/conf.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,3 +95,9 @@ rst_prolog = """
 .. role:: img-title-para
 
 """
+
+# -- Options for LaTeX output -------------------------------------------------
+
+latex_elements = {
+    'classoptions': ',openany,oneside'
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,6 @@ testing =
     isort
 
 docs =
-    Sphinx == 6.2.1
+    Sphinx == 5.1.0
     sphinx-rtd-theme >= 0.5.0
     doc8 >= 0.8.1


### PR DESCRIPTION
Made changes in the .readthedocs.yaml to enable format for downloading pdf and epub versions of the documentation.
Also made changes in the docs/conf.py to make the generated pdfs without blank pages.

Implemented same fix as done in [this](https://github.com/nexB/aboutcode/issues/125) issue which was merged in [this](https://github.com/nexB/aboutcode/pull/127) PR.

I have added pdf and epub options in the .readthedocs.yaml file and have tested the documentation in readthedocs. The pdf and epub versions of the documentation can now be downloaded.

You can check the generated RTD pdf from my forked repository [here](https://skeleton-nexb.readthedocs.io/_/downloads/en/latest/pdf/)

@AyanSinhaMahapatra please check and let me know if any other changes are required in this PR.
<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://aboutcode.readthedocs.io/en/latest/doc_maintenance.html#continuous-integration) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
Signed-off-by: Arijit De [arijitde2050@gmail.com](mailto:arijitde2050@gmail.com)