### PR TITLE
Deprecate MacOS-13 CI runners

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,14 +33,6 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: macos13_cpython
-          image_name: macOS-13
-          python_versions: ['3.10', '3.11', '3.12', '3.13', '3.14']
-          test_suites:
-              all: venv/bin/pytest -n 2 -vvs
-
-    - template: etc/ci/azure-posix.yml
-      parameters:
           job_name: macos14_cpython
           image_name: macOS-14
           python_versions: ['3.10', '3.11', '3.12', '3.13', '3.14']


### PR DESCRIPTION
We already have macos 14 and 15 runner images enabled so we don't need to replace these runners.

Reference: https://github.com/actions/runner-images/issues/13046