### PR TITLE
Replace tagged versions with commit hashes in github actions

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.12
 
@@ -40,7 +40,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload built archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: pypi_archives
           path: dist/*
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: pypi_archives
           path: dist
 
       - name: Create GH release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           draft: true
           files: dist/*
@@ -77,11 +77,11 @@ jobs:
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: pypi_archives
           path: dist
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b


### PR DESCRIPTION
Updates:

* setup-python: v5 -> [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0)
* checkout: v4 -> [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)
* upload-artifact: v4 -> [v6.0.0](https://github.com/actions/upload-artifact/releases/tag/v6.0.0)
* download-artifact: v4 -> [v7.0.0](https://github.com/actions/download-artifact/releases/tag/v7.0.0)
* action-gh-release: v2 -> [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0)
* gh-action-pypi-publish: release/v1 -> [1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0)